### PR TITLE
Support server.url and server.description options in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ we explain the options that can be set.
 |force_update_schema|Force update schema from routes data|`false`|
 |use_tag_namespace|Use namespace for tag name|`true`|
 |use_schema_namespace|Use namespace for schema name|`true`|
+|server.url| Server url | `http://localhost:3000` |
+|server.description| Server description | `localhost` |
 
 ## Environment variables
 

--- a/lib/routes_to_swagger_docs/configuration.rb
+++ b/lib/routes_to_swagger_docs/configuration.rb
@@ -1,5 +1,7 @@
 #frozen_string_literal: true
 
+require_relative './configuration/server'
+
 module RoutesToSwaggerDocs
   module Configuration
 
@@ -9,6 +11,7 @@ module RoutesToSwaggerDocs
     DEFAULT_FORCE_UPDATE_SCHEMA = false
     DEFAULT_USE_TAG_NAMESPACE = true
     DEFAULT_USE_SCHEMA_NAMESPACE = true
+    DEFAULT_SERVER = Server.new
 
     VALID_OPTIONS_KEYS = [
       :root_dir_path,
@@ -16,7 +19,8 @@ module RoutesToSwaggerDocs
       :doc_save_file_name,
       :force_update_schema,
       :use_tag_namespace,
-      :use_schema_namespace
+      :use_schema_namespace,
+      :server
     ]
 
     attr_accessor *VALID_OPTIONS_KEYS
@@ -44,6 +48,7 @@ module RoutesToSwaggerDocs
       self.force_update_schema  = DEFAULT_FORCE_UPDATE_SCHEMA
       self.use_tag_namespace    = DEFAULT_USE_TAG_NAMESPACE
       self.use_schema_namespace = DEFAULT_USE_SCHEMA_NAMESPACE
+      self.server               = DEFAULT_SERVER
     end
   end
 end

--- a/lib/routes_to_swagger_docs/configuration/server.rb
+++ b/lib/routes_to_swagger_docs/configuration/server.rb
@@ -1,0 +1,32 @@
+#frozen_string_literal: true
+
+module RoutesToSwaggerDocs
+  module Configuration
+    class Server
+      DEFAULT_URL = "http://localhost:3000"
+      DEFAULT_DESCRIPTION = "localhost"
+
+      VALID_OPTIONS_KEYS = [
+        :url,
+        :description
+      ]
+
+      attr_accessor *VALID_OPTIONS_KEYS
+
+      def new
+        set_default
+      end
+
+      def configure
+        yield self
+      end
+
+      private
+
+      def set_default
+        self.url         = DEFAULT_URL
+        self.description = DEFAULT_DESCRIPTION
+      end
+    end
+  end
+end

--- a/lib/routes_to_swagger_docs/schema/v3/server_object.rb
+++ b/lib/routes_to_swagger_docs/schema/v3/server_object.rb
@@ -6,8 +6,8 @@ module RoutesToSwaggerDocs
       class ServerObject < BaseObject
         def to_doc
           {
-            "url" => "http://localhost:3000",
-            "description" => "localhost",
+            "url" => "#{server.url}",
+            "description" => "#{server.description}",
             # Do not Server Variable Object
           }
         end


### PR DESCRIPTION
## Summary

- Support `server.url` and `server.description` options in configuration

The setting also goes like this:

```ruby
RoutesToSwaggerDocs.configure do |config|
    config.root_dir_path = "./swagger_docs"
    config.schema_save_dir_name = "schema"
    config.doc_save_file_name = "swagger_doc.yml"
    config.force_update_schema = false
    config.use_tag_namespace = true
    config.use_schema_namespace = false

    config.server.configure do |server|
      server.url = "http://example.com"
      server.description = "example"
    end
  end
```