### PR TITLE
Fix bugs for rake tasks

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -152,4 +152,6 @@ Layout/EndAlignment:
   Exclude:
     - 'lib/routes_to_swagger_docs/shared/sortable.rb'
 
-
+Security/YAMLLoad:
+  Exclude:
+    - 'lib/routes_to_swagger_docs/schema/editor.rb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       eventmachine (~> 1.2.0)
       paint
       rails (~> 4.2.5)
-      terminal-table
+      terminal-table (~> 1.6.0)
       watir (~> 6.0)
 
 GEM
@@ -149,8 +149,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    terminal-table (1.8.0)
-      unicode-display_width (~> 1.1, >= 1.1.1)
+    terminal-table (1.6.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     tzinfo (1.2.5)

--- a/lib/routes_to_swagger_docs/schema/editor.rb
+++ b/lib/routes_to_swagger_docs/schema/editor.rb
@@ -92,7 +92,7 @@ module RoutesToSwaggerDocs
         @browser ||= Watir::Browser.new
         @browser.goto(url)
         if wait_for_loaded
-          schema_doc_from_local = YAML.load_file(doc_save_file_path)
+          schema_doc_from_local = YAML.load(doc_save_file_path)
           @browser.driver.local_storage[storage_key] = schema_doc_from_local.to_yaml
           @browser.refresh
         end

--- a/routes_to_swagger_docs.gemspec
+++ b/routes_to_swagger_docs.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'eventmachine', '~> 1.2.0'
   spec.add_runtime_dependency 'paint'
   spec.add_runtime_dependency 'rails', '~> 4.2.5'
-  spec.add_runtime_dependency 'terminal-table'
+  spec.add_runtime_dependency 'terminal-table', '~> 1.6.0'
   spec.add_runtime_dependency 'watir', '~> 6.0'
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
## Summary

-  downgrade `terminal-table`
-  Use `YAML.load` instead of `YAML.safe_load`