### PR TITLE
Rename methods

### DIFF
--- a/lib/routes_to_swagger_docs/schema/analyzer.rb
+++ b/lib/routes_to_swagger_docs/schema/analyzer.rb
@@ -16,21 +16,21 @@ module RoutesToSwaggerDocs
         @components_analyzer = ComponentsAnalyzer.new(@before_schema_data, @after_schema_data, options)
       end
 
-      def update_from_schema
+      def analyze_docs
         logger.info '[Analyze Swagger file] start'
         @after_schema_data.keys.each do |schema_name|
           case schema_name
           when 'paths'
             logger.info '[Analyze Swagger file (paths)] start'
-            @path_analyzer.update_from_schema
+            @path_analyzer.analyze_docs
             logger.info '[Analyze Swagger file (paths)] end'
           when 'tags'
             logger.info '[Analyze Swagger file (tags)] start'
-            @tag_analyzer.update_from_schema
+            @tag_analyzer.analyze_docs
             logger.info '[Analyze Swagger file (tags)] end'
           when 'components'
             logger.info '[Analyze Swagger file (components)] start'
-            @components_analyzer.update_from_schema
+            @components_analyzer.analyze_docs
             logger.info '[Analyze Swagger file (components)] end'
           else
             save_schema_when(schema_name)

--- a/lib/routes_to_swagger_docs/schema/analyzer/base_analyzer.rb
+++ b/lib/routes_to_swagger_docs/schema/analyzer/base_analyzer.rb
@@ -17,7 +17,7 @@ module RoutesToSwaggerDocs
         @after_schema_data  = after_schema_data.presence || create_after_schema_data
       end
 
-      def update_from_schema
+      def analyze_docs
         raise NoImplementError
       end
 

--- a/lib/routes_to_swagger_docs/schema/analyzer/components/request_bodies_analyzer.rb
+++ b/lib/routes_to_swagger_docs/schema/analyzer/components/request_bodies_analyzer.rb
@@ -9,7 +9,7 @@ module RoutesToSwaggerDocs
   module Schema
     module Components
       class RequestBodiesAnalyzer < BaseAnalyzer
-        def update_from_schema
+        def analyze_docs
           diff_manager = RequestBodyDiffManager.new(@before_schema_data, @after_schema_data)
           diff_manager.process_by_using_diff_data do |request_body_name, is_removed, is_added, after_edited_data|
             file_manager = Components::RequestBodyFileManager.new("#/components/requestBodies/#{request_body_name}", :ref)

--- a/lib/routes_to_swagger_docs/schema/analyzer/components/schemas_analyzer.rb
+++ b/lib/routes_to_swagger_docs/schema/analyzer/components/schemas_analyzer.rb
@@ -9,7 +9,7 @@ module RoutesToSwaggerDocs
   module Schema
     module Components
       class SchemasAnalyzer < BaseAnalyzer
-        def update_from_schema
+        def analyze_docs
           diff_manager = SchemaDiffManager.new(@before_schema_data, @after_schema_data)
           diff_manager.process_by_using_diff_data do |schema_name, is_removed, is_added, after_edited_data|
             file_manager = Components::SchemaFileManager.new("#/components/schemas/#{schema_name}", :ref)

--- a/lib/routes_to_swagger_docs/schema/analyzer/components_analyzer.rb
+++ b/lib/routes_to_swagger_docs/schema/analyzer/components_analyzer.rb
@@ -14,13 +14,13 @@ module RoutesToSwaggerDocs
         @components_request_bodies_analyzer = Components::RequestBodiesAnalyzer.new(before_schema_data, after_schema_data, options)
       end
 
-      def update_from_schema
+      def analyze_docs
         logger.info '[Analyze Swagger file (components/schemas)] start'
-        @components_schemas_analyzer.update_from_schema
+        @components_schemas_analyzer.analyze_docs
         logger.info '[Analyze Swagger file (components/schemas)] end'
 
         logger.info '[Analyze Swagger file (components/requestBodies)] start'
-        @components_request_bodies_analyzer.update_from_schema
+        @components_request_bodies_analyzer.analyze_docs
         logger.info '[Analyze Swagger file (components/requestBodies)] end'
       end
     end

--- a/lib/routes_to_swagger_docs/schema/analyzer/path_analyzer.rb
+++ b/lib/routes_to_swagger_docs/schema/analyzer/path_analyzer.rb
@@ -7,7 +7,7 @@ require_relative '../manager/file/path_item_file_manager'
 module RoutesToSwaggerDocs
   module Schema
     class PathAnalyzer < BaseAnalyzer
-      def update_from_schema
+      def analyze_docs
         sorted_schema = deep_sort(@after_schema_data, 'paths')
         edited_paths_schema = sorted_schema['paths']
 

--- a/lib/routes_to_swagger_docs/schema/analyzer/tag_analyzer.rb
+++ b/lib/routes_to_swagger_docs/schema/analyzer/tag_analyzer.rb
@@ -16,7 +16,7 @@ module RoutesToSwaggerDocs
         @diff_manager = TagDiffManager.new(before_schema_data, after_schema_data)
       end
 
-      def update_from_schema
+      def analyze_docs
         save_file_path = @file_manager.save_file_path
         case @type
         when :edited

--- a/lib/routes_to_swagger_docs/schema/editor.rb
+++ b/lib/routes_to_swagger_docs/schema/editor.rb
@@ -67,7 +67,7 @@ module RoutesToSwaggerDocs
         save_edited_schema
         conv_after_schema_data = YAML.load(@after_schema_data)
         analyzer = Analyzer.new(@before_schema_data, conv_after_schema_data, options)
-        analyzer.update_from_schema
+        analyzer.analyze_docs
       end
 
       def ensure_save_tmp_schema_file

--- a/lib/routes_to_swagger_docs/schema/generator/base_generator.rb
+++ b/lib/routes_to_swagger_docs/schema/generator/base_generator.rb
@@ -20,7 +20,7 @@ module RoutesToSwaggerDocs
       private
 
       attr_accessor :unit_paths_file_path
-      attr_accessor :skip_generate_schemas
+      attr_accessor :skip_generate_docs
       attr_accessor :skip_load_dot_paths
 
       # Scope Rails

--- a/lib/routes_to_swagger_docs/schema/generator/components/request_body_generator.rb
+++ b/lib/routes_to_swagger_docs/schema/generator/components/request_body_generator.rb
@@ -17,13 +17,13 @@ module RoutesToSwaggerDocs
           @glob_schema_paths = create_glob_components_request_bodies_paths
         end
 
-        def generate_components_request_bodies
+        def generate_docs
           if components_request_bodies_file_do_not_exists?
             logger.info ' <From routes data>'
-            generate_components_request_bodies_from_routes_data
+            generate_docs_from_routes_data
           else
             logger.info ' <From schema files>'
-            generate_components_request_bodies_from_schema_fiels
+            generate_docs_from_schema_fiels
           end
         end
 
@@ -33,7 +33,7 @@ module RoutesToSwaggerDocs
         alias components_request_bodies_files_paths schema_files_paths
         alias components_request_bodies_file_do_not_exists? schema_file_do_not_exists?
 
-        def generate_components_request_bodies_from_schema_fiels
+        def generate_docs_from_schema_fiels
           components_request_bodies_from_schema_files = components_request_bodies_files_paths.each_with_object({}) do |path, data|
             yaml = YAML.load_file(path)
             data.deep_merge!(yaml)
@@ -41,18 +41,18 @@ module RoutesToSwaggerDocs
             logger.info "  Fetch Components schema file: \t#{full_path}"
           end
           @components_request_bodies.deep_merge!(components_request_bodies_from_schema_files['components']['requestBodies'])
-          process_when_generate_components_request_bodies do |save_file_path|
+          process_when_generate_docs do |save_file_path|
             logger.info "  Merge schema file: \t#{save_file_path}"
           end
         end
 
-        def generate_components_request_bodies_from_routes_data
-          process_when_generate_components_request_bodies do |save_file_path|
+        def generate_docs_from_routes_data
+          process_when_generate_docs do |save_file_path|
             logger.info "  Write schema file: \t#{save_file_path}"
           end
         end
 
-        def process_when_generate_components_request_bodies
+        def process_when_generate_docs
           logger.info ' <Update Components schema files (components/schemas)>'
           @components_request_bodies.each do |schema_name, data|
             result_content = {

--- a/lib/routes_to_swagger_docs/schema/generator/components/schema_generator.rb
+++ b/lib/routes_to_swagger_docs/schema/generator/components/schema_generator.rb
@@ -16,13 +16,13 @@ module RoutesToSwaggerDocs
           @glob_schema_paths = create_glob_components_schemas_paths
         end
 
-        def generate_components_schemas
+        def generate_docs
           if components_schemas_file_do_not_exists?
             logger.info ' <From routes data>'
-            generate_components_schemas_from_routes_data
+            generate_docs_from_routes_data
           else
             logger.info ' <From schema files>'
-            generate_components_schemas_from_schema_fiels
+            generate_docs_from_schema_fiels
           end
         end
 
@@ -32,7 +32,7 @@ module RoutesToSwaggerDocs
         alias components_schemas_files_paths schema_files_paths
         alias components_schemas_file_do_not_exists? schema_file_do_not_exists?
 
-        def generate_components_schemas_from_schema_fiels
+        def generate_docs_from_schema_fiels
           components_schemas_from_schema_files = components_schemas_files_paths.each_with_object({}) do |path, data|
             yaml = YAML.load_file(path)
             data.deep_merge!(yaml)
@@ -41,18 +41,18 @@ module RoutesToSwaggerDocs
           end
           @components_schemas.deep_merge!(components_schemas_from_schema_files['components']['schemas'])
 
-          process_when_generate_components_schemas do |save_file_path|
+          process_when_generate_docs do |save_file_path|
             logger.info "  Merge schema file: \t#{save_file_path}"
           end
         end
 
-        def generate_components_schemas_from_routes_data
-          process_when_generate_components_schemas do |save_file_path|
+        def generate_docs_from_routes_data
+          process_when_generate_docs do |save_file_path|
             logger.info "  Write schema file: \t#{save_file_path}"
           end
         end
 
-        def process_when_generate_components_schemas
+        def process_when_generate_docs
           logger.info ' <Update Components schema files (components/schemas)>'
           @components_schemas.each do |schema_name, data|
             result = {

--- a/lib/routes_to_swagger_docs/schema/generator/components_generator.rb
+++ b/lib/routes_to_swagger_docs/schema/generator/components_generator.rb
@@ -13,12 +13,12 @@ module RoutesToSwaggerDocs
         @options = options
       end
 
-      def generate_components
+      def generate_docs
         @components.each do |key, _value|
           if key == 'schemas'
-            Components::SchemaGenerator.new(@components, @options).generate_components_schemas
+            Components::SchemaGenerator.new(@components, @options).generate_docs
           elsif key == 'requestBodies'
-            Components::RequestBodyGenerator.new(@components, @options).generate_components_request_bodies
+            Components::RequestBodyGenerator.new(@components, @options).generate_docs
           end
         end
       end

--- a/lib/routes_to_swagger_docs/schema/generator/doc_generator.rb
+++ b/lib/routes_to_swagger_docs/schema/generator/doc_generator.rb
@@ -18,7 +18,7 @@ module RoutesToSwaggerDocs
 
       def generate_docs
         logger.info '[Generate Swagger schema files] start'
-        @schema_generator.generate_docs unless skip_generate_schemas
+        @schema_generator.generate_docs unless skip_generate_docs
         logger.info '[Generate Swagger schema files] end'
         logger.info '[Generate Swagger docs from schema files] start'
         generate_docs_from_schema_files

--- a/lib/routes_to_swagger_docs/schema/generator/doc_generator.rb
+++ b/lib/routes_to_swagger_docs/schema/generator/doc_generator.rb
@@ -35,7 +35,7 @@ module RoutesToSwaggerDocs
         end
 
         result = if many_paths_file_paths.present?
-                   Squeezer.new(result_before_squeeze, many_paths_file_paths: many_paths_file_paths).remake_docs
+                   Squeezer.new(result_before_squeeze, many_paths_file_paths: many_paths_file_paths).squeeze_docs
                  else
                    result_before_squeeze
                  end

--- a/lib/routes_to_swagger_docs/schema/generator/doc_generator.rb
+++ b/lib/routes_to_swagger_docs/schema/generator/doc_generator.rb
@@ -18,7 +18,7 @@ module RoutesToSwaggerDocs
 
       def generate_docs
         logger.info '[Generate Swagger schema files] start'
-        @schema_generator.generate_schemas unless skip_generate_schemas
+        @schema_generator.generate_docs unless skip_generate_schemas
         logger.info '[Generate Swagger schema files] end'
         logger.info '[Generate Swagger docs from schema files] start'
         generate_docs_from_schema_files

--- a/lib/routes_to_swagger_docs/schema/generator/path_generator.rb
+++ b/lib/routes_to_swagger_docs/schema/generator/path_generator.rb
@@ -15,13 +15,13 @@ module RoutesToSwaggerDocs
         @glob_schema_paths = create_glob_paths_paths
       end
 
-      def generate_paths
+      def generate_docs
         if paths_file_do_not_exists?
           logger.info ' <From routes data>'
-          generate_paths_from_routes_data
+          generate_docs_from_routes_data
         else
           logger.info ' <From schema files>'
-          generate_paths_from_schema_fiels
+          generate_docs_from_schema_fiels
         end
       end
 
@@ -30,19 +30,19 @@ module RoutesToSwaggerDocs
       alias paths_files_paths schema_files_paths
       alias paths_file_do_not_exists? schema_file_do_not_exists?
 
-      def generate_paths_from_schema_fiels
-        process_when_generate_paths do |save_file_path|
+      def generate_docs_from_schema_fiels
+        process_when_generate_docs do |save_file_path|
           logger.info "  Merge schema file: \t#{save_file_path}"
         end
       end
 
-      def generate_paths_from_routes_data
-        process_when_generate_paths do |save_file_path|
+      def generate_docs_from_routes_data
+        process_when_generate_docs do |save_file_path|
           logger.info "  Write schema file: \t#{save_file_path}"
         end
       end
 
-      def process_when_generate_paths
+      def process_when_generate_docs
         logger.info ' <Update schema files (paths)>'
         save_each_tags(@paths) do |tag_name, result|
           relative_path = "paths/#{tag_name}"

--- a/lib/routes_to_swagger_docs/schema/generator/schema_generator.rb
+++ b/lib/routes_to_swagger_docs/schema/generator/schema_generator.rb
@@ -15,31 +15,31 @@ module RoutesToSwaggerDocs
         @options = options
       end
 
-      def generate_schemas
+      def generate_docs
         if force_update_schema || schema_file_do_not_exists?
           logger.info '<From routes data>'
-          generate_schemas_from_routes_data
+          generate_docs_from_routes_data
         else
           logger.info '<From schema files>'
-          generate_schemas_from_schema_fiels
+          generate_docs_from_schema_fiels
         end
       end
 
       private
 
-      def generate_schemas_from_schema_fiels
-        process_when_generate_schemas do |save_file_path|
+      def generate_docs_from_schema_fiels
+        process_when_generate_docs do |save_file_path|
           logger.info " Merge schema file: \t#{save_file_path}"
         end
       end
 
-      def generate_schemas_from_routes_data
-        process_when_generate_schemas do |save_file_path|
+      def generate_docs_from_routes_data
+        process_when_generate_docs do |save_file_path|
           logger.info " Write schema file: \t#{save_file_path}"
         end
       end
 
-      def process_when_generate_schemas
+      def process_when_generate_docs
         logger.info '<Update schema files>'
         @docs.each do |field_name, data|
           result = { field_name.to_s => data }
@@ -47,11 +47,11 @@ module RoutesToSwaggerDocs
           case field_name
           when 'paths'
             logger.info ' [Generate Swagger schema files (paths)] start'
-            PathGenerator.new(result, @options).generate_paths
+            PathGenerator.new(result, @options).generate_docs
             logger.info ' [Generate Swagger schema files (paths)] end'
           when 'components'
             logger.info ' [Generate Swagger schema files (components)] start'
-            ComponentsGenerator.new(result, @options).generate_components
+            ComponentsGenerator.new(result, @options).generate_docs
             logger.info ' [Generate Swagger schema files (components)] end'
           else
             file_manager = FileManager.new(field_name, :relative)

--- a/lib/routes_to_swagger_docs/schema/monitor.rb
+++ b/lib/routes_to_swagger_docs/schema/monitor.rb
@@ -36,7 +36,7 @@ module RoutesToSwaggerDocs
         options = { type: :edited }
         @after_schema_data = fetch_after_schema_data
         analyzer = Analyzer.new(@before_schema_data, @after_schema_data, options)
-        analyzer.update_from_schema
+        analyzer.analyze_docs
       end
 
       def ensure_save_tmp_schema_file

--- a/lib/routes_to_swagger_docs/schema/squeezer.rb
+++ b/lib/routes_to_swagger_docs/schema/squeezer.rb
@@ -8,7 +8,7 @@ require_relative 'squeezer/components_squeezer'
 module RoutesToSwaggerDocs
   module Schema
     class Squeezer < BaseSqueezer
-      def remake_docs
+      def squeeze_docs
         except_paths_schema = @schema_data.except('paths', 'tags', 'components')
 
         path_squeezer = PathSqueezer.new(@schema_data, many_paths_file_paths: many_paths_file_paths)
@@ -16,9 +16,9 @@ module RoutesToSwaggerDocs
         components_squeezer = ComponentsSqueezer.new(@schema_data, many_paths_file_paths: many_paths_file_paths)
 
         slice_schemas = [
-          tag_squeezer.remake_docs,
-          path_squeezer.remake_docs,
-          components_squeezer.remake_docs
+          tag_squeezer.squeeze_docs,
+          path_squeezer.squeeze_docs,
+          components_squeezer.squeeze_docs
         ]
         slice_schemas.each_with_object(except_paths_schema) { |slice_schema, result| result.deep_merge!(slice_schema) }
       end

--- a/lib/routes_to_swagger_docs/schema/squeezer/base_squeezer.rb
+++ b/lib/routes_to_swagger_docs/schema/squeezer/base_squeezer.rb
@@ -11,7 +11,7 @@ module RoutesToSwaggerDocs
         @tag_names = create_tag_names
       end
 
-      def remake_docs
+      def squeeze_docs
         raise 'Please inplement in inherited class.'
       end
 

--- a/lib/routes_to_swagger_docs/schema/squeezer/components/request_body_squeezer.rb
+++ b/lib/routes_to_swagger_docs/schema/squeezer/components/request_body_squeezer.rb
@@ -6,7 +6,7 @@ module RoutesToSwaggerDocs
   module Schema
     module Components
       class RequestBodySqueezer < BaseSqueezer
-        def remake_docs
+        def squeeze_docs
           { 'requestBodies' => @schema_data['components']['requestBodies'] }
         end
       end

--- a/lib/routes_to_swagger_docs/schema/squeezer/components/schema_squeezer.rb
+++ b/lib/routes_to_swagger_docs/schema/squeezer/components/schema_squeezer.rb
@@ -6,7 +6,7 @@ module RoutesToSwaggerDocs
   module Schema
     module Components
       class SchemaSqueezer < BaseSqueezer
-        def remake_docs
+        def squeeze_docs
           { 'schemas' => @schema_data['components']['schemas'] }
         end
       end

--- a/lib/routes_to_swagger_docs/schema/squeezer/components_squeezer.rb
+++ b/lib/routes_to_swagger_docs/schema/squeezer/components_squeezer.rb
@@ -13,13 +13,13 @@ module RoutesToSwaggerDocs
         @request_body_squeezer = Components::RequestBodySqueezer.new(schema_data, options)
       end
 
-      def remake_docs
+      def squeeze_docs
         slice_components_schema = @schema_data['components'].keys.each_with_object({}) do |key, result|
           if key == 'schemas'
-            data = @schema_squeezer.remake_docs
+            data = @schema_squeezer.squeeze_docs
             result.deep_merge!(data)
           elsif key == 'requestBodies'
-            data = @request_body_squeezer.remake_docs
+            data = @request_body_squeezer.squeeze_docs
             result.deep_merge!(data)
           end
         end

--- a/lib/routes_to_swagger_docs/schema/squeezer/path_squeezer.rb
+++ b/lib/routes_to_swagger_docs/schema/squeezer/path_squeezer.rb
@@ -5,7 +5,7 @@ require_relative 'base_squeezer'
 module RoutesToSwaggerDocs
   module Schema
     class PathSqueezer < BaseSqueezer
-      def remake_docs
+      def squeeze_docs
         slice_paths_schema = @schema_data['paths'].each_with_object({}) do |(path, data_when_path), result|
           data_when_path.values.each do |data_when_verb|
             include_tag_name = data_when_verb['tags'].first.in? @tag_names

--- a/lib/routes_to_swagger_docs/schema/squeezer/tag_squeezer.rb
+++ b/lib/routes_to_swagger_docs/schema/squeezer/tag_squeezer.rb
@@ -5,7 +5,7 @@ require_relative 'base_squeezer'
 module RoutesToSwaggerDocs
   module Schema
     class TagSqueezer < BaseSqueezer
-      def remake_docs
+      def squeeze_docs
         slice_tags_schema = @schema_data['tags'].each_with_object([]) do |tag, result|
           eql_tag_name = tag['name'].in? @tag_names
           result.push(tag) if eql_tag_name

--- a/lib/routes_to_swagger_docs/schema/v3/components/request_body_object.rb
+++ b/lib/routes_to_swagger_docs/schema/v3/components/request_body_object.rb
@@ -10,12 +10,12 @@ module RoutesToSwaggerDocs
         class RequestBodyObject < RoutesToSwaggerDocs::Plugins::Schema::V3::HookableBaseObject
           def initialize(route_data, path)
             super()
-            @path_comp                      = Routing::PathComponent.new(path)
-            @path                           = @path_comp.symbol_to_brace
-            @route_data                     = route_data
-            @verb                           = route_data[:verb]
-            @tag_name                       = route_data[:tag_name]
-            @schema_name                    = route_data[:schema_name]
+            @path_comp   = Routing::PathComponent.new(path)
+            @path        = @path_comp.symbol_to_brace
+            @route_data  = route_data
+            @verb        = route_data[:verb]
+            @tag_name    = route_data[:tag_name]
+            @schema_name = route_data[:schema_name]
           end
 
           def to_doc

--- a/lib/routes_to_swagger_docs/schema/v3/tag_object.rb
+++ b/lib/routes_to_swagger_docs/schema/v3/tag_object.rb
@@ -13,13 +13,13 @@ module RoutesToSwaggerDocs
 
         def to_doc
           @tags_data.each_with_object([]) do |tag_name, result|
-            result.push(build_doc(tag_name))
+            result.push(create_doc(tag_name))
           end
         end
 
         private
 
-        def build_doc(tag_name)
+        def create_doc(tag_name)
           {
             'name' => tag_name,
             'description' => "#{tag_name} description",

--- a/lib/routes_to_swagger_docs/tasks/main.rake
+++ b/lib/routes_to_swagger_docs/tasks/main.rake
@@ -27,7 +27,7 @@ namespace :routes do
       analyzer = RoutesToSwaggerDocs::Schema::Analyzer.new({}, {}, analyzer_options)
       analyzer.analyze_docs
 
-      generator_options = { skip_generate_schemas: true }
+      generator_options = { skip_generate_docs: true }
       generator = RoutesToSwaggerDocs::Schema::Generator.new(generator_options)
       generator.generate_docs
 
@@ -38,7 +38,7 @@ namespace :routes do
     task editor: [:common] do
       logger.info '[Routes to Swagger docs] start'
 
-      generator_options = { unit_paths_file_path: unit_paths_file_path, skip_generate_schemas: true }
+      generator_options = { unit_paths_file_path: unit_paths_file_path, skip_generate_docs: true }
       generator = RoutesToSwaggerDocs::Schema::Generator.new(generator_options)
       generator.generate_docs
 
@@ -54,7 +54,7 @@ namespace :routes do
     task ui: [:common] do
       logger.info '[Routes to Swagger docs] start'
 
-      generator_options = { unit_paths_file_path: unit_paths_file_path, skip_generate_schemas: true }
+      generator_options = { unit_paths_file_path: unit_paths_file_path, skip_generate_docs: true }
       generator = RoutesToSwaggerDocs::Schema::Generator.new(generator_options)
       generator.generate_docs
 
@@ -69,7 +69,7 @@ namespace :routes do
     task monitor: [:common] do
       logger.info '[Routes to Swagger docs] start'
 
-      generator_options = { unit_paths_file_path: unit_paths_file_path, skip_generate_schemas: true }
+      generator_options = { unit_paths_file_path: unit_paths_file_path, skip_generate_docs: true }
       generator = RoutesToSwaggerDocs::Schema::Generator.new(generator_options)
       generator.generate_docs
 

--- a/lib/routes_to_swagger_docs/tasks/main.rake
+++ b/lib/routes_to_swagger_docs/tasks/main.rake
@@ -25,7 +25,7 @@ namespace :routes do
 
       analyzer_options = { type: :existing, existing_schema_file_path: existing_schema_file_path }
       analyzer = RoutesToSwaggerDocs::Schema::Analyzer.new({}, {}, analyzer_options)
-      analyzer.update_from_schema
+      analyzer.analyze_docs
 
       generator_options = { skip_generate_schemas: true }
       generator = RoutesToSwaggerDocs::Schema::Generator.new(generator_options)

--- a/lib/routes_to_swagger_docs/tasks/tool.rake
+++ b/lib/routes_to_swagger_docs/tasks/tool.rake
@@ -13,7 +13,7 @@ namespace :routes do
     task deploy: [:common] do
       logger.info '[Routes to Swagger docs] start'
 
-      generator_options = { unit_paths_file_path: unit_paths_file_path, skip_generate_schemas: true }
+      generator_options = { unit_paths_file_path: unit_paths_file_path, skip_generate_docs: true }
       generator = RoutesToSwaggerDocs::Schema::Generator.new(generator_options)
       generator.generate_docs
 
@@ -50,7 +50,7 @@ namespace :routes do
       logger.level = :null
 
       logger.info '[Routes to Swagger docs] start'
-      generator_options = { skip_generate_schemas: true, skip_load_dot_paths: true }
+      generator_options = { skip_generate_docs: true, skip_load_dot_paths: true }
       generator = RoutesToSwaggerDocs::Schema::Generator.new(generator_options)
       generator.generate_docs
 


### PR DESCRIPTION
## Summary

- Rename  from `generate_*` to `generate_docs_*`
- Rename from `remake_docs` to `squeeze_docs`
- Rename from `update_from_schema` to `analyze_docs`
- Rename from  `skip_generate_schema` to `skip_generate_docs`