### PR TITLE
Fix Selenium::WebDriver::Error::UnknownError(#64)

### DIFF
--- a/lib/routes_to_swagger_docs/schema/editor.rb
+++ b/lib/routes_to_swagger_docs/schema/editor.rb
@@ -89,7 +89,8 @@ module RoutesToSwaggerDocs
       end
 
       def open_browser_and_set_schema
-        @browser ||= Watir::Browser.new
+        capabilities = { "chromeOptions" => {'w3c' => false } }
+        @browser ||= Watir::Browser.new(:chrome, capabilities)
         @browser.goto(url)
         if wait_for_loaded
           schema_doc_from_local = YAML.load_file(doc_save_file_path)


### PR DESCRIPTION
## Summary

It seems that W3C mode has become default ON from v75

>The most noticeable change is ChromeDriver now runs in W3C standard compliant mode by default. Other changes include:

http://chromedriver.chromium.org/downloads

In the fix, execute w3c mode off as before